### PR TITLE
Improve password operation when loading the app

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -196,14 +196,31 @@ export class CopayApp {
       this.statusBar.backgroundColorByName('white');
       this.splashScreen.hide();
 
-      // Subscribe Resume
-      this.onResumeSubscription = this.platform.resume.subscribe(() => {
-        // Check PIN or Fingerprint on Resume
-        this.openLockModal();
-      });
-
-      // Check PIN or Fingerprint
-      this.openLockModal();
+      this.profile
+        .loadAndBindProfile()
+        .then(profile => {
+          if (profile.credentials.length > 0) {
+            // Subscribe Resume
+            this.onResumeSubscription = this.platform.resume.subscribe(() => {
+              // Check PIN or Fingerprint on Resume
+              this.openLockModal();
+            });
+            // Check PIN or Fingerprint
+            this.openLockModal();
+          } else {
+            // if all wallets are deleted,
+            // reset profile and back to OnBoarding page
+            this.profile.resetProfile();
+            this.rootPage = OnboardingPage;
+          }
+        })
+        .catch((err: Error) => {
+          this.logger.warn('LoadAndBindProfile', err.message);
+          this.rootPage =
+            err.message == 'ONBOARDINGNONCOMPLETED: Onboarding non completed'
+              ? OnboardingPage
+              : DisclaimerPage;
+        });
     }
 
     // this.registerIntegrations();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,3 +1,4 @@
+import { OnboardingPage } from './../pages/onboarding/onboarding';
 import { Component, Renderer, ViewChild } from '@angular/core';
 import { Device } from '@ionic-native/device';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
@@ -199,7 +200,7 @@ export class CopayApp {
       this.profile
         .loadAndBindProfile()
         .then(profile => {
-          if (profile.credentials.length > 0) {
+          if (profile && profile.credentials.length > 0) {
             // Subscribe Resume
             this.onResumeSubscription = this.platform.resume.subscribe(() => {
               // Check PIN or Fingerprint on Resume
@@ -216,10 +217,7 @@ export class CopayApp {
         })
         .catch((err: Error) => {
           this.logger.warn('LoadAndBindProfile', err.message);
-          this.rootPage =
-            err.message == 'ONBOARDINGNONCOMPLETED: Onboarding non completed'
-              ? OnboardingPage
-              : DisclaimerPage;
+          this.rootPage = OnboardingPage;
         });
     }
 

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -100,6 +100,9 @@
           <button ion-button class="button-standard" (click)="importWallet()">
             {{'Import a wallet' | translate}}
           </button>
+          <button ion-button class="button-standard" (click)="shoBackToOnboardingPopup()">
+            {{'Create wallets' | translate}}
+          </button>
         </div>
       </div>
 

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -3,6 +3,7 @@ import { StatusBar } from '@ionic-native/status-bar';
 import { TranslateService } from '@ngx-translate/core';
 import * as echarts from 'echarts';
 import {
+  App,
   Events,
   ModalController,
   NavController,
@@ -18,6 +19,7 @@ import { BitPayCardPage } from '../integrations/bitpay-card/bitpay-card';
 import { BitPayCardIntroPage } from '../integrations/bitpay-card/bitpay-card-intro/bitpay-card-intro';
 import { CoinbasePage } from '../integrations/coinbase/coinbase';
 import { ShapeshiftPage } from '../integrations/shapeshift/shapeshift';
+import { OnboardingPage } from '../onboarding/onboarding';
 import { PaperWalletPage } from '../paper-wallet/paper-wallet';
 // import { ScanPage } from '../scan/scan';
 import { AmountPage } from '../send/amount/amount';
@@ -117,6 +119,7 @@ export class HomePage {
   private latestVersion: string;
 
   constructor(
+    private app: App,
     private plt: Platform,
     private navCtrl: NavController,
     private profileProvider: ProfileProvider,
@@ -487,6 +490,21 @@ export class HomePage {
       leading: true
     }
   );
+
+  public shoBackToOnboardingPopup(): void {
+    let title = this.translate.instant('Warning!');
+    let message = this.translate.instant(
+      'Are you sure you want to go back to onboarding page to create default wallets?'
+    );
+    this.popupProvider.ionicConfirm(title, message, null, null).then(res => {
+      if (res) this.backToOnboarding();
+    });
+  }
+
+  public backToOnboarding() {
+    this.profileProvider.resetProfile();
+    this.app.getRootNavs()[0].setRoot(OnboardingPage);
+  }
 
   /**
    * handle the change of the coin type of wallets to display

--- a/src/pages/send/send.ts
+++ b/src/pages/send/send.ts
@@ -206,7 +206,8 @@ export class SendPage extends WalletTabsChild {
     network: string;
   }): boolean {
     return this.wallet
-      ? this.wallet.coin === recipient.coin &&
+      ? (this.wallet.coin === recipient.coin ||
+          (this.wallet.coin === 'try' && recipient.coin === 'eth')) &&
           this.wallet.network === recipient.network
       : true;
   }
@@ -433,7 +434,7 @@ export class SendPage extends WalletTabsChild {
           name: item.name,
           email: item.email,
           color: item.color,
-          coin: item.coin,
+          coin: this.wallet.coin,
           network: item.network
         });
       })

--- a/src/pages/settings/addressbook/add/add.html
+++ b/src/pages/settings/addressbook/add/add.html
@@ -40,6 +40,7 @@
         type="text"
         [value]="addressBookAdd.value.address"
         address-validator
+        class="input-check"
       ></ion-input>
     </ion-item>
     <ion-icon

--- a/src/pages/settings/addressbook/add/add.scss
+++ b/src/pages/settings/addressbook/add/add.scss
@@ -85,7 +85,12 @@ page-addressbook-add {
   .item-ios.item-label-floating .text-input {
     margin: 0;
     padding: 0 0 0 8px;
-    width: auto;
+    width: 100%;
+  }
+
+  .item-ios.item-label-stacked .input-check .text-input,
+  .item-ios.item-label-floating .input-check .text-input {
+    padding-right: 32px;
   }
 
   .scanner-icon {

--- a/src/pages/settings/addressbook/modify/modify.html
+++ b/src/pages/settings/addressbook/modify/modify.html
@@ -48,7 +48,7 @@
         type="text"
         [value]="addressBookAdd.value.address"
         address-validator
-        [disabled]="true"
+        class="input-check"
       ></ion-input>
     </ion-item>
     <ion-icon

--- a/src/pages/settings/addressbook/modify/modify.scss
+++ b/src/pages/settings/addressbook/modify/modify.scss
@@ -85,7 +85,12 @@ page-addressbook-add {
   .item-ios.item-label-floating .text-input {
     margin: 0;
     padding: 0 0 0 8px;
-    width: auto;
+    width: 100%;
+  }
+
+  .item-ios.item-label-stacked .input-check .text-input,
+  .item-ios.item-label-floating .input-check .text-input {
+    padding-right: 32px;
   }
 
   .scanner-icon {

--- a/src/providers/profile/profile.ts
+++ b/src/providers/profile/profile.ts
@@ -739,9 +739,9 @@ export class ProfileProvider {
         this.askPassword(warnMsg, title).then((password: string) => {
           if (!password) {
             this.showWarningNoEncrypt().then(() => {
-              this.encrypt(wallet, fromOnboarding).then(() => {
-                return resolve();
-              });
+              // this.encrypt(wallet, fromOnboarding).then(() => {
+                return reject();
+              // });
             });
           } else {
             title = this.translate.instant(
@@ -1107,7 +1107,7 @@ export class ProfileProvider {
     this.persistenceProvider.storeNewProfile(this.profile);
   }
 
-  private resetProfile(): void {
+  public resetProfile(): void {
     this.logger.debug('----Clearing wallets...');
     this.wallet = {};
     _.each(this.profile.credentials, credentials => {


### PR DESCRIPTION
Bugfixs:
- Fix bug where users could not use the PIN to decrypt the app after deleting all wallets.
- Fix bug: due to the operation of "Create Wallet" in the onboarding view, the encrypt password was inquired indefinitely, and the user could not return to the onboarding view to import a wallet.

Improve:
- If no more wallet exists in the app, show options to return back to onboading view, then users can create new wallets or import wallets.
- Operation of setting password can be canceled and back to onboading page.
